### PR TITLE
Require Fabric 1.X; currently incompatible with 2.X

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Fabric>=1.12.0
+Fabric>=1.12.0,<2.0
 boto3>=1.4.3
 PyYAML>=3.12


### PR DESCRIPTION
Fabric 2.X exists now which is incompatible with this code.  This fix prevents 2.X+ from being installed.

Please merge